### PR TITLE
__init__.py now imports all iterators, removing one unnecessary layer

### DIFF
--- a/infinibatch/__init__.py
+++ b/infinibatch/__init__.py
@@ -276,3 +276,5 @@ scenarios require more complex combinations of data. To create those, you will n
 to compose the necessary data reader from the underlying building blocks.
 This is described at the documentation of the module `iterators`.
 """
+
+from .iterators import *


### PR DESCRIPTION
One can now say:
```
import infinibatch as ib
itr = ib.InfinitePermutationSourceIterator([1,2,3])
```