### PR TITLE
Add experimental mode to PrefetchIterator that moves prefetch buffer to main process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install torch
+      run: |
+        pip install torch==1.7.1
     - name: Run unit tests
       run: |
         python -m unittest discover -s ./test

--- a/.gitignore
+++ b/.gitignore
@@ -490,3 +490,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Infinibatch is a library of checkpointable iterators for randomized data loading
 
 ## Getting Started
 
-Infinibatch requires Python 3.5 and has no dependencies.
+Infinibatch requires Python 3.6 or higher and has no dependencies.
 There is presently no pip package.
 
 To install it, clone this repository and install it locally.

--- a/infinibatch/iterators.py
+++ b/infinibatch/iterators.py
@@ -1066,6 +1066,8 @@ class _ForkPrefetchIterator(CheckpointableIterator):
     def _terminate_and_join_queue_fetcher_thread(self):
         self._queue_fetcher_thread_running = False  # signal thread to halt
         if self._queue_fetcher_thread is not None:
+            while not self._local_queue.empty():
+                self._local_queue.get()
             self._queue_fetcher_thread.join()
         self._queue_fetcher_thread = None
 

--- a/infinibatch/iterators.py
+++ b/infinibatch/iterators.py
@@ -875,13 +875,14 @@ def BlockwiseShuffleIterator(source_iterator: CheckpointableIterator, block_size
     return samples
 
 
-def PrefetchIterator(source_iterator: CheckpointableIterator, buffer_size: int):
+def PrefetchIterator(source_iterator: CheckpointableIterator, buffer_size: int, log_empty_queue_warning: bool=False):
     """
     An iterator prefetching data into a buffer on a seperate process.
 
     Args:
         source_iterator: checkpointable iterator to recur over
         buffer_size: number of items to prefetch; this is the maximum number of items held in the prefetch queue
+        log_empty_queue_warning: log warning message if prefetch buffer is empty
     """
     if not isinstance(source_iterator, CheckpointableIterator):
         raise ValueError('source_iterator has to be a CheckpointableIterator')
@@ -896,11 +897,8 @@ def PrefetchIterator(source_iterator: CheckpointableIterator, buffer_size: int):
                This also means that checkpoints of this iterator pipeline cannot be ported to a system that uses fork.')
         return source_iterator
     else:
-        return _ForkPrefetchIterator(source_iterator, buffer_size)
+        return _ForkPrefetchIterator(source_iterator, buffer_size, log_empty_queue_warning)
 
-# TODO:
-# - debugging facilities
-# - make process / thread start-up lazy?
 
 class _ForkPrefetchIterator(CheckpointableIterator):
     """
@@ -909,6 +907,7 @@ class _ForkPrefetchIterator(CheckpointableIterator):
     Args:
         source_iterator: checkpointable iterator to recur over
         buffer_size: number of items to prefetch; this is the maximum number of items held in the prefetch queue
+        log_empty_queue_warning: log warning message if prefetch buffer is empty
     """
 
     # HOW THIS ITERATOR WORKS, AND WHY:
@@ -959,9 +958,10 @@ class _ForkPrefetchIterator(CheckpointableIterator):
     # https://bugs.python.org/issue7946
     # https://in.pycon.org/2011/static/files/talks/41/Python-threads_v1.0.pdf
 
-    def __init__(self, source_iterator: CheckpointableIterator, buffer_size: int):
+    def __init__(self, source_iterator: CheckpointableIterator, buffer_size: int, log_empty_queue_warning: bool=False):
         self._source_iterator = source_iterator  # type: CheckpointableIterator
         self._buffer_size = buffer_size          # type: int
+        self._log_empty_queue_warning = log_empty_queue_warning
         self._prefetch_process = None            # type: Optional[multiprocessing.Process]
         self._queue_fetcher_thread = None
         self._queue_fetcher_thread_running = False
@@ -1023,20 +1023,7 @@ class _ForkPrefetchIterator(CheckpointableIterator):
 
     def _queue_fetcher_thread_fn(self):
         while self._queue_fetcher_thread_running:
-            # debug_queue_size_before = in_queue.qsize()
-            # start = time.time()
             msg = self._inter_process_queue.get()
-            # stop = time.time()
-            # debug_queue_size_after = in_queue.qsize()
-            # if debug_queue_size_before == 0:
-            #     logger.warning(f"THREAD: tried to fetch data, but prefetch queue was empty")
-            #     logger.warning(f"THREAD: queue size before: {debug_queue_size_before}")
-            #     logger.warning(f"THREAD: queue size after: {debug_queue_size_after}")
-            # diff = stop - start
-            # if diff > 0.1:
-                # logger.warning(f"THREAD: time to fetch item: {diff}s")
-                # logger.warning(f"THREAD: queue size before: {debug_queue_size_before}")
-                # logger.warning(f"THREAD: queue size after: {debug_queue_size_after}")
             self._local_queue.put(msg)
             if isinstance(msg, StopIteration):
                 return
@@ -1044,6 +1031,11 @@ class _ForkPrefetchIterator(CheckpointableIterator):
     def __next__(self):
         if self._prefetch_process is None:  # iterator has already been exhausted
             raise StopIteration()
+        if self._log_empty_queue_warning:
+            import logging
+            logger = logging.getLogger(__name__)
+            if self._local_queue.empty():
+                logger.warning("trying to fetch item, but local queue is empty")
         msg = self._local_queue.get()
         if isinstance(msg, StopIteration):
             self._terminate_and_join_queue_fetcher_thread()

--- a/infinibatch/iterators.py
+++ b/infinibatch/iterators.py
@@ -1035,7 +1035,7 @@ class _ForkPrefetchIterator(CheckpointableIterator):
             import logging
             logger = logging.getLogger(__name__)
             if self._local_queue.empty():
-                logger.warning("trying to fetch item, but local queue is empty")
+                logger.warning("trying to fetch item, but prefetch buffer is empty")
         msg = self._local_queue.get()
         if isinstance(msg, StopIteration):
             self._terminate_and_join_queue_fetcher_thread()

--- a/test/test_iterators.py
+++ b/test/test_iterators.py
@@ -112,6 +112,7 @@ class TestFiniteIteratorCheckpointingMixin:
         for case_name, _, it in self.test_cases:
             with self.subTest(case_name):
                 list(it)  # exhaust iterator
+                self.assertRaises(StopIteration, it.__next__)
                 checkpoint = it.getstate()  # take checkpoint
                 it.setstate(None)  # reset to beginning
                 it.setstate(checkpoint)  # reset to checkpoint


### PR DESCRIPTION
This PR adds a new experimental mode to the PrefetchIterator, which moves the prefetch buffer from the prefetch process to the main process. This change resolves long hangs we experienced with the previous implementation in certain situations. More details on this problem can be found in the expansive comments in the code, which I will also paste here:

    # HOW THIS ITERATOR WORKS, AND WHY:
    #
    # This iterator offloads the work of evaluating all preceeding iterators
    # into a separate prefetch process and tries to maintain a buffer
    # of buffer_size many items in order to hide any latency spikes in the evaluation
    # of the preceeding iterators.
    #
    # The prefetch process (self._prefetch_process) generates items and puts them
    # into an inter-process queue (self._inter_process_queue). This queue is of type
    # multiprocessing.SimpleQueue, which is essentially a pipe with some locks.
    # This queue does not store any items beyond the capacity of the pipe,
    # which is typically very small. Its sole purpose is to act as a means for
    # inter-process communication. Its purpose is NOT to act as the above-mentioned buffer.
    # 
    # The actual buffer is realized as a local, thread-safe queue (queue.Queue) that lives
    # in the main process (self._local_queue). We create a thread (self._queue_fetcher_thread)
    # within the main process that is responsible for fetching items from the
    # inter-process queue and storing them in the local queue. We then obtain an item from the
    # local queue whenever __next__ is called within the main thread of the main process.
    #
    # You might wonder why we are jumping through all these hoops instead of just using
    # a multiprocessing.Queue with the desired buffer_size to act as both a means for
    # inter-process communication and as a buffer to smooth out latency at the same time.
    # In fact, this iterator used to be implemented that way.
    # However, we observed severe issues with that implementation.
    #
    # Specifically, with multiprocessing.Queue the buffer lives in the prefetch process
    # and a queue feeding thread is responsible for moving items from the buffer onto the pipe
    # (see https://docs.python.org/3.6/library/multiprocessing.html#multiprocessing.Queue).
    # The main thread in the prefetch process, which is responsible for generating items,
    # competes with the queue feeder thread for CPU cycles, and because of CPython's
    # global interpreter lock only one of these two processes can run at any given time.
    # 
    # We observed situations in which the main thread is so busy generating new items
    # that the queue feeder thread does not get enough CPU time to keep the pipe filled.
    # This starvation of the queue feeder thread led to severe hangs (up to a minute)
    # in calls to multiprocessing.Queue.get in the main process, even though the buffer had
    # hundreds of items stored in it.
    #
    # This problem gets even worse when PyTorch tensors are sent over the queue. PyTorch registers
    # custom reducers to the ForkingPickler used to pickle tensors before sending them over a pipe
    # (see https://github.com/pytorch/pytorch/blob/master/torch/multiprocessing/reductions.py).
    # As a consequence, the actual tensor data is not sent via the queue, but shared via shared
    # memory. This process involves spawning yet another thread in the prefetch process and opening
    # sockets to transmit file descriptors
    # (see https://pytorch.org/docs/stable/multiprocessing.html#file-descriptor-file-descriptor).
    # So in this case, there is yet another thread competing for the global interpreter lock.
    # 
    # The present implementation moves the buffer from the prefetch process to the main process.
    # For the case that the queue carries non-tensor data, this means that the prefetch process
    # only has one thread, which alternatingly generates an item and then puts it onto the
    # inter-process queue in an operation that blocks if the pipe is full. This removes the
    # starvation problem described above and alleviates the hangs.
    #
    # For the case that the queue carries PyTorch tensors, we still get a separate thread in the
    # prefetch process that is responsible for feeding the sockets involved in transferring
    # file descriptors, and we still observe hangs in calls to multiprocessing.Queue.get in this case.
    # However, these hangs are not stalling the data loading process anymore as long as the buffer
    # is not empty because the buffer now lives in the main process.
    #
    # We suspect the hanging issues described above to be manifestations of the "Convoy effect":
    # https://bugs.python.org/issue7946
    # http://www.dabeaz.com/python/GIL.pdf
    # https://in.pycon.org/2011/static/files/talks/41/Python-threads_v1.0.pdf