### PR TITLE
Improve experimental PrefetchIterator

### DIFF
--- a/infinibatch/iterators.py
+++ b/infinibatch/iterators.py
@@ -1204,6 +1204,7 @@ class _ForkPrefetchIteratorExperimental(CheckpointableIterator):
             args=(self._source_iterator, self._item_offset, self._buffer_size, self._inter_process_queue),
         )
         _prefetch_process.start()  # this invokes fork()
+        # set self._prefetch_process after fork so that variable never exists for within prefetch process
         self._prefetch_process = _prefetch_process
 
         # set up queue fetcher thread

--- a/infinibatch/iterators.py
+++ b/infinibatch/iterators.py
@@ -1292,7 +1292,7 @@ class _ForkPrefetchIteratorExperimental(CheckpointableIterator):
                 # no more items are taken from the inter-process queue.
                 # This event is used to communicate to the prefetch process that it is safe to terminate.
                 should_terminate_event.wait()
-                return
+                break
             if item_offset == buffer_size - 1:
                 # for efficiency, we send a new source state only at the END of each window of length _buffer_size
                 # this is the state for retrieving the NEXT element, i.e. the first element of the next buffer
@@ -1306,7 +1306,8 @@ class _ForkPrefetchIteratorExperimental(CheckpointableIterator):
                 inter_process_queue, msg, should_terminate_event
             )
             if should_terminate:
-                return
+                break
+        source_iterator.close()
 
     def _queue_fetcher_thread_fn(self):
         while True:

--- a/test/test_iterators.py
+++ b/test/test_iterators.py
@@ -414,6 +414,19 @@ class TestPrefetchIteratorExperimental(TestBase, TestFiniteIteratorMixin, TestFi
         f = lambda: it.setstate(None)
         self.assertRaises(RuntimeError, f)
 
+    def test_nested(self):
+        for n in self.lengths:
+            for buffer_size in self.lengths:
+                for depth in [2, 3, 4, 5]:
+                    with self.subTest("n={}, buffer_size={}, depth={}".format(n, buffer_size, depth)):
+                        data = [torch.Tensor([float(i)]) for i in range(n)]
+                        it = NativeCheckpointableIterator(copy.deepcopy(data))
+                        for _ in range(depth):
+                            it = PrefetchIterator(it, buffer_size, buffer_in_main_process=True)
+                        result = list(it)
+                        self.assertEqual(result, data)
+                        it.close()
+
     def test_torch_tensors(self):
         for n in self.lengths:
             for buffer_size in self.lengths:

--- a/test/test_iterators.py
+++ b/test/test_iterators.py
@@ -1,5 +1,6 @@
 import copy
 import itertools
+import multiprocessing
 from random import Random
 import unittest
 
@@ -404,6 +405,8 @@ class TestPrefetchIteratorExperimental(TestBase, TestFiniteIteratorMixin, TestFi
         self.assertRaises(ValueError, f)
 
     def test_closing(self):
+        if multiprocessing.get_start_method() != 'fork':
+            return # dummy iterator used, skip test
         it = PrefetchIterator(NativeCheckpointableIterator([0]), buffer_size=42, buffer_in_main_process=True)
         it.close()
         f = lambda: it.__next__()

--- a/test/test_iterators.py
+++ b/test/test_iterators.py
@@ -403,6 +403,14 @@ class TestPrefetchIteratorExperimental(TestBase, TestFiniteIteratorMixin, TestFi
         f = lambda: PrefetchIterator(NativeCheckpointableIterator([0]), buffer_size=0, buffer_in_main_process=True)
         self.assertRaises(ValueError, f)
 
+    def test_closing(self):
+        it = PrefetchIterator(NativeCheckpointableIterator([0]), buffer_size=42, buffer_in_main_process=True)
+        it.close()
+        f = lambda: it.__next__()
+        self.assertRaises(RuntimeError, f)
+        f = lambda: it.setstate(None)
+        self.assertRaises(RuntimeError, f)
+
     def test_torch_tensors(self):
         for n in self.lengths:
             for buffer_size in self.lengths:
@@ -413,6 +421,11 @@ class TestPrefetchIteratorExperimental(TestBase, TestFiniteIteratorMixin, TestFi
                     )
                     result = list(it)
                     self.assertEqual(result, data)
+
+    def tearDown(self):
+        if hasattr(self, "test_cases"):
+            for _, _, it in self.test_cases:
+                it.close()
 
 
 class TestMultiplexIterator(TestBase, TestFiniteIteratorMixin, TestFiniteIteratorCheckpointingMixin):

--- a/test/test_iterators.py
+++ b/test/test_iterators.py
@@ -421,6 +421,7 @@ class TestPrefetchIteratorExperimental(TestBase, TestFiniteIteratorMixin, TestFi
                     )
                     result = list(it)
                     self.assertEqual(result, data)
+                    it.close()
 
     def tearDown(self):
         if hasattr(self, "test_cases"):


### PR DESCRIPTION
The following changes apply to the new experimental prefetcher implementation:
- Add close() function to explicitly release resources (processes, threads, queues, ...) of PrefetchIterators. This function is implemented for every iterator and recursively traverses a pipeline of iterators, closing all prefetchers in the pipeline. It is now mandatory to call this function once a prefetcher is no longer needed. This mirrors the implementation of classes such as multiprocessing.Pool in Python's library.
- Lazy startup: Prefetchers now only start up the background processes and threads on the first call to __next__(), not on calling setstate().
- All processes and threads now terminate gracefully instead of being terminated from the outside.
- Add unit tests for nested prefetchers.